### PR TITLE
fix error due to API change

### DIFF
--- a/library/Facebook/base_facebook.php
+++ b/library/Facebook/base_facebook.php
@@ -392,8 +392,7 @@ abstract class BaseFacebook
       return false;
     }
 
-    $response_params = array();
-    parse_str($access_token_response, $response_params);
+    $response_params = json_decode($access_token_response, true);
 
     if (!isset($response_params['access_token'])) {
       return false;
@@ -804,8 +803,7 @@ abstract class BaseFacebook
       return false;
     }
 
-    $response_params = array();
-    parse_str($access_token_response, $response_params);
+    $response_params = json_decode($access_token_response, true);
     if (!isset($response_params['access_token'])) {
       return false;
     }


### PR DESCRIPTION
The Facebook API changed. Now the access token response returns a JSON string. This is a hotfix for the old PHP SDK that this extension still uses. (The new one can be found under [github.com/facebook/php-graph-sdk](https://github.com/facebook/php-graph-sdk))

See

* https://community.contao.org/de/showthread.php?66249-facebook_login-Token-Problem
* https://developers.facebook.com/bugs/1790606087933487/

for more information.